### PR TITLE
[HISTORY]: actionText for users.length !== 1

### DIFF
--- a/src/components/molecules/History/History.tsx
+++ b/src/components/molecules/History/History.tsx
@@ -105,9 +105,13 @@ const History: React.FC<IProps> = ({ history, isUZADO, attachments, host = windo
             )}
           </div>
           <div className='rf-history__details-column'>
-            {r.user.length === 1 && (
+            {r.user.length === 1 ? (
               <p className='rf-history__details-info'>
                 {isUZADO ? r.user[0].position : r.activityText}
+              </p>
+            ) : (
+              <p className='rf-history__details-info'>
+                {r.activityText}
               </p>
             )}
 


### PR DESCRIPTION
Если paths.users не равен 1, то у нас не отображался статус запроса (шаг / actionText), хотя даже если users > 1, то actionText для всех одинаковый.
Я добавил else условие, чтобы добавлялся actionText для users.length !== 1.